### PR TITLE
Update the release issue template's regression checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,16 +19,23 @@ Please ensure these items are checked before merging.
 - Performed successful integration test with `github/github`
   - [ ] Install release `{{ env.release_name }}`
   - [ ] Verify CI passes
-- [ ] Manually verify regressions on following pages against production:
-- `/about/diversity`
-- `/contact-sales`
-- `/education`
-- `/enterprise/advanced-security`
-- `/enterprise`
-- `/features/copilot/getting-started`
-- `/features/copilot`
-- `/features/preview`
-- `/mobile`
-- `/resources/articles/security/what-is-application-security`
-- `/resources/articles/security`
-- `/solutions/devops`
+- [ ] Manually verify no regressions on the following pages against production:
+  - [ ] `/about` (https://github.com/about)
+  - [ ] `/education` (https://github.com/education)
+  - [ ] `/enterprise` (https://github.com/enterprise)
+  - [ ] `/events/universe/recap` (https://github.com/events/universe/recap)
+  - [ ] `/features` (https://github.com/features)
+  - [ ] `/features/actions` (https://github.com/features/actions)
+  - [ ] `/features/ai/github-app` (https://github.com/features/ai/github-app)
+  - [ ] `/features/copilot` (https://github.com/features/copilot)
+  - [ ] `/features/copilot/ai-code-editor` (https://github.com/features/copilot/ai-code-editor)
+  - [ ] `/features/copilot/plans` (https://github.com/features/copilot/plans)
+  - [ ] `/home` (https://github.com/home)
+  - [ ] `/mobile` (https://github.com/mobile)
+  - [ ] `/pricing` (https://github.com/pricing)
+  - [ ] `/resources/articles/what-is-application-security` (https://github.com/resources/articles/what-is-application-security)
+  - [ ] `/security` (https://github.com/security)
+  - [ ] `/security/advanced-security` (https://github.com/security/advanced-security)
+  - [ ] `/security/plans` (https://github.com/security/plans)
+  - [ ] `/solutions/use-case/devops` (https://github.com/solutions/use-case/devops)
+  - [ ] `/why-github` (https://github.com/why-github)


### PR DESCRIPTION
The manual regression checklist in the release issue template (`.github/ISSUE_TEMPLATE.md`) had drifted from the pages actually built with `@primer/react-brand`. Several listed paths now 404 (`/contact-sales`) or redirect (`/enterprise/advanced-security` → `/security/advanced-security`, `/features/copilot/getting-started`, `/solutions/devops`, the `/resources/articles/security…` paths), so reviewers were verifying stale URLs.

This refreshes the list to the current set of brand-powered pages — the React landing pages in `github-ui`'s `landing-pages` package plus a representative sample of Contentful (SWP) pages — cross-checked as live against production and against the SWP page inventory.

It also tidies the format: one alphabetically sorted list, each page as its own checkbox with a production link appended so it can be opened and ticked off in one click.